### PR TITLE
Improve mobile card hand layout

### DIFF
--- a/frontend/src/components/GameTableView.js
+++ b/frontend/src/components/GameTableView.js
@@ -160,9 +160,9 @@ const GameTableView = ({ playerId, currentTableState, handleLeaveTable, handleLo
         setChatOpen(false);
     };
 
-    const renderCard = (cardString, { isButton = false, onClick = null, disabled = false, isSelected = false, small = false, large = false, isFaceDown = false, style: customStyle = {} } = {}) => {
-        const width = large ? '65px' : (small ? '30px' : '45px');
-        const height = large ? '90px' : (small ? '50px' : '70px');
+    const renderCard = (cardString, { isButton = false, onClick = null, disabled = false, isSelected = false, small = false, large = false, isFaceDown = false, style: customStyle = {}, className = '' } = {}) => {
+        const width = large ? '80px' : (small ? '40px' : '70px');
+        const height = large ? '110px' : (small ? '60px' : '100px');
 
         if (isFaceDown) {
             return (
@@ -197,13 +197,13 @@ const GameTableView = ({ playerId, currentTableState, handleLeaveTable, handleLo
         const backgroundColor = SUIT_BACKGROUNDS[suit] || 'white';
         let borderStyle = isSelected ? '3px solid royalblue' : '1px solid #777';
         const baseFontSize = large ? '1.3em' : (small ? '0.8em' : '1em');
-        const style = { padding: large ? '10px' : (small ? '4px' : '8px'), border: borderStyle, borderRadius: '4px', backgroundColor: isSelected ? 'lightblue' : backgroundColor, color: color, margin: '3px', minWidth: width, height, textAlign: 'center', fontWeight: 'bold', fontSize: baseFontSize, cursor: isButton && !disabled ? 'pointer' : 'default', display: 'flex', flexDirection: 'column', justifyContent: 'center', alignItems: 'center', ...customStyle };
+        const style = { padding: large ? '10px' : (small ? '4px' : '8px'), border: borderStyle, borderRadius: '8px', backgroundColor: isSelected ? 'lightblue' : backgroundColor, color: color, margin: '3px', minWidth: width, height, textAlign: 'center', fontWeight: 'bold', fontSize: baseFontSize, cursor: isButton && !disabled ? 'pointer' : 'default', display: 'flex', flexDirection: 'column', justifyContent: 'center', alignItems: 'center', boxShadow: '0 2px 4px rgba(0,0,0,0.3)', ...customStyle };
 
         const symbolStyle = { fontSize: '125%' };
         const cardContent = <>{rank !== '?' && rank}<span style={symbolStyle}>{symbol}</span></>;
 
-        if (isButton) return (<button key={cardString} onClick={onClick} disabled={disabled} style={style}>{cardContent}</button>);
-        return (<span key={cardString} style={{ ...style, display: 'inline-flex' }}>{cardContent}</span>);
+        if (isButton) return (<button key={cardString} onClick={onClick} disabled={disabled} style={style} className={className}>{cardContent}</button>);
+        return (<span key={cardString} style={{ ...style, display: 'inline-flex' }} className={className}>{cardContent}</span>);
     };
 
     const handleForfeit = () => {

--- a/frontend/src/components/game/PlayerHand.css
+++ b/frontend/src/components/game/PlayerHand.css
@@ -1,0 +1,24 @@
+.player-hand-cards {
+    position: relative;
+    display: flex;
+    justify-content: center;
+    align-items: flex-end;
+    padding: 5px;
+    max-width: 90vw;
+    margin: 0 auto;
+}
+
+.player-hand-cards.my-turn {
+    animation: pulsing-glow 1.5s infinite;
+    border-radius: 8px;
+}
+
+.player-hand-card {
+    transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.player-hand-card:hover,
+.player-hand-card:active {
+    transform: translateY(-8px);
+    box-shadow: 0 4px 8px rgba(0,0,0,0.4);
+}

--- a/frontend/src/components/game/PlayerHand.js
+++ b/frontend/src/components/game/PlayerHand.js
@@ -1,4 +1,5 @@
 import React, { useState, useEffect, useCallback } from 'react';
+import './PlayerHand.css';
 import { RANKS_ORDER, SUIT_SORT_ORDER } from '../../constants';
 
 // Helper function for card sorting
@@ -25,9 +26,18 @@ const PlayerHand = ({
     renderCard
 }) => {
     const [selectedDiscards, setSelectedDiscards] = useState([]);
+    const [windowWidth, setWindowWidth] = useState(typeof window !== 'undefined' ? window.innerWidth : 0);
 
     const { state, hands, bidWinnerInfo, revealedWidowForFrog } = currentTableState;
     const myHand = hands[selfPlayerName] || [];
+
+    useEffect(() => {
+        const handleResize = () => {
+            setWindowWidth(window.innerWidth);
+        };
+        window.addEventListener('resize', handleResize);
+        return () => window.removeEventListener('resize', handleResize);
+    }, []);
 
     useEffect(() => {
         if (state !== "Frog Widow Exchange") {
@@ -84,16 +94,31 @@ const PlayerHand = ({
     const myHandToDisplay = sortHandBySuit(myHand);
     const isMyTurnToPlay = state === "Playing Phase" && currentTableState.trickTurnPlayerName === selfPlayerName;
 
+    const cardWidth = 70; // width used in renderCard for large cards
+    const N = myHandToDisplay.length;
+    const handAreaWidth = windowWidth * 0.85;
+    let overlap = 0;
+    if (N > 1) {
+        overlap = Math.max(0, cardWidth - ((handAreaWidth - cardWidth) / (N - 1)));
+        if (N <= 3) overlap = 0;
+    }
+
     return (
         <div style={{ flexGrow: 1, display: 'flex', justifyContent: 'center', alignItems: 'center' }}>
-            {/* --- MODIFICATION: Added a className for responsive styling --- */}
-            <div className="player-hand-cards">
+            <div className={`player-hand-cards${isMyTurnToPlay ? ' my-turn' : ''}`}>
                 {myHandToDisplay.map((card, index) => renderCard(card, {
                     key: card,
                     isButton: true,
                     onClick: () => handlePlayCard(card),
                     disabled: !isMyTurnToPlay,
-                    style: { animation: `fadeIn 0.5s ease-out forwards`, animationDelay: `${index * 0.05}s`, opacity: 0 }
+                    style: {
+                        animation: `fadeIn 0.5s ease-out forwards`,
+                        animationDelay: `${index * 0.05}s`,
+                        opacity: 0,
+                        marginLeft: index === 0 ? 0 : `-${overlap}px`,
+                        zIndex: index,
+                    },
+                    className: 'player-hand-card'
                 }))}
             </div>
         </div>


### PR DESCRIPTION
## Summary
- style cards with larger sizes and drop shadows
- compute overlap for the player's hand so cards spread out as the hand shrinks
- highlight hand area on the player's turn and add card hover effects

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_687d39519a388320befd2d13991497ae