### PR TITLE
Fix missing transaction time column

### DIFF
--- a/backend/src/data/createTables.js
+++ b/backend/src/data/createTables.js
@@ -86,6 +86,9 @@ const createDbTables = async (pool) => {
             );
         `);
 
+        // Ensure transaction_time column exists (for existing databases)
+        await pool.query("ALTER TABLE transactions ADD COLUMN IF NOT EXISTS transaction_time TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP");
+
         await pool.query(`
             CREATE TABLE IF NOT EXISTS feedback (
                 feedback_id SERIAL PRIMARY KEY,


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Add `ALTER TABLE` to ensure `transaction_time` column exists in `transactions` table, fixing mercy token database errors.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
The `CREATE TABLE IF NOT EXISTS` statement only creates tables if they don't exist, but doesn't add new columns to existing tables. This `ALTER TABLE` ensures the `transaction_time` column is added to existing production databases that were deployed before this column was introduced, resolving the "column does not exist" error for mercy token requests.

---

[Open in Web](https://cursor.com/agents?id=bc-263b79c4-2edd-430f-b846-7e2d0e335a8b) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-263b79c4-2edd-430f-b846-7e2d0e335a8b) • [Open Docs](https://docs.cursor.com/background-agent/web-and-mobile)